### PR TITLE
Fixed a check that will fail if jsel is used to generate a DOM and then ...

### DIFF
--- a/jsel.js
+++ b/jsel.js
@@ -4072,7 +4072,7 @@ module.exports = jsel = (function () {
 
     Utilities.instance_of = function (o, c) {
         while (o != null) {
-            if (o.constructor === c) {
+            if (o.constructor.name === c.name) {
                 return true;
             }
             if (o === Object) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsel",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "DOM 3 XPath implementation for JavaScript objects.",
 	"engines": {
 		"node": ">=0.10.0"
@@ -8,6 +8,11 @@
 	"author": {
 		"name": "Ali Chamas"
 	},
+	"contributors": [
+		{
+			"name": "Tim Harrington"
+		}
+	],
 	"dependencies": {},
 	"devDependencies": {
 		"mocha": "1.12.x"


### PR DESCRIPTION
...later jsel is loaded again into the node.js process's namespace but this time from a different location on the filesystem. When this happens the XNodeSet used to parse the DOM will not be the same as the XNodeSet being checked against during function evaluation. For example, in the case of Functions.count, the second argument to the instance_of call will resolve to the most recently created XNodeSet and not the original one used to parse the DOM. Thus the check o.constructor === c will incorrectly fail.
