### PR TITLE
Fix addCustomFunction for source mangling

### DIFF
--- a/jsel.js
+++ b/jsel.js
@@ -3262,7 +3262,7 @@ var jsel = (function () {
 
     FunctionResolver.customFunctions = {};
     FunctionResolver.addCustomFunction = function (ns, ln, fn) {
-        var func;
+        var func = function () { return null; };
         eval('func = ' + fn.toString());
         this.customFunctions["{" + (ns ? ns : '') + "}" + ln] = func;
     };


### PR DESCRIPTION
Using uglify-js 2.8.16  to minify this source (installed by from gulp-uglify 2.1.2, configured with mangle and compress enabled) results in a problem with the "func" variable inside FunctionResolver.addCustomFunction() (called by jsel.addFunction() ). Since it is uninitialized, the assignment to "this.customFunctions" is optimized changing "func" with "void 0", thus ignoring the "eval" statement, resulting in not adding the function. Initializing "func" with a "no-op" function seems to fix this.